### PR TITLE
Remove addHeaderFile call

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -3,6 +3,8 @@ Changelog
 
 Patches and Bug Fixes:
 - Remove servo block family
+- Remove unneeded tinker.h import
+- Change TinkerButtonBlock to be an AbstractTinkerReadDigitalBlock
 
 ========== Version 2.0.0 ==========
 

--- a/src/main/java/com/ardublock/translator/block/tinker/TinkerButtonBlock.java
+++ b/src/main/java/com/ardublock/translator/block/tinker/TinkerButtonBlock.java
@@ -7,25 +7,12 @@ import com.ardublock.translator.block.TranslatorBlock;
 import com.ardublock.translator.block.exception.SocketNullException;
 import com.ardublock.translator.block.exception.SubroutineNotDeclaredException;
 
-/*
 public class TinkerButtonBlock extends AbstractTinkerReadDigitalBlock
 {
 
 	public TinkerButtonBlock(Long blockId, Translator translator, String codePrefix, String codeSuffix, String label)
 	{
 		super(blockId, translator, codePrefix, codeSuffix, label);
-	}
-}
-
-*/
-
-public class TinkerButtonBlock extends TranslatorBlock
-{
-
-	public TinkerButtonBlock(Long blockId, Translator translator, String codePrefix, String codeSuffix, String label)
-	{
-		super(blockId, translator, codePrefix, codeSuffix, label);
-		translator.addHeaderFile("TinkerKit.h");
 	}
 	
 	@Override


### PR DESCRIPTION
- new versions of Arduino IDE remove the library as standard it seems
- also changes TinkerButtonBlock to extend AbstractTinkerReadDigitalBlock